### PR TITLE
Fix capitilisation in titles & paragraph margins/line breaks

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -252,8 +252,8 @@ class DocPath:
         # The replacement might not be necessary, filenames cannot contain double quotes
         title = " ".join(
             [
-                item if item[0].isupper() else item.title()
-                for item in self.old_path.stem.split(" ")
+                #item if item[0].isupper() else item.title()
+                item for item in self.old_path.stem.split(" ")
             ]
         ).replace('"', r"\"")
         return title

--- a/zola/sass/bootstrap/scss/_reboot.scss
+++ b/zola/sass/bootstrap/scss/_reboot.scss
@@ -130,7 +130,7 @@ h6 {
 p {
   margin-top: 0;
   // margin-bottom: $paragraph-margin-bottom;
-  margin-bottom: 0;
+  margin-bottom: 5;
 }
 
 


### PR DESCRIPTION
Titles were being messed with, "FOO" would become "Foo" with only the initial character capitalised.
Hope I'm doing this correctly, never done a pull request before