### PR TITLE
Make table of content render relative links

### DIFF
--- a/zola/templates/macros/docs-toc.html
+++ b/zola/templates/macros/docs-toc.html
@@ -5,11 +5,11 @@
   			<nav id="TableOfContents">
   					<ul>
   							{% for h1 in page.toc %}
-  							<li><a href="{{ h1.permalink | safe}}">{{ h1.title }}</a></li>
+  							<li><a href="{{ h1.permalink |  safe | replace(from=page.permalink, to='') }}">{{ h1.title }}</a></li>
   							{% if h1.children %}
   									<ul>
   											{% for h2 in h1.children %}
-  											<li><a href="{{ h2.permalink | safe }}">{{ h2.title }}</a></li>
+  											<li><a href="{{ h2.permalink | safe | replace(from=page.permalink, to='') }}">{{ h2.title }}</a></li>
   											{% endfor %}
   									</ul>
   							{% endif %}


### PR DESCRIPTION
We need to use relative links for the anchor (`#`) to work.

Original changes: https://github.com/orditeck/cheap-publish/commit/a4d07cdb86a7c06b20a832cb9da7bdf562ae85da?diff=unified Look at my fork for more customization and fixes: https://github.com/orditeck/cheap-publish

Closes https://github.com/Yarden-zamir/obsidian-zola-plus/issues/14